### PR TITLE
ser: allow creating a custom `Serializer`

### DIFF
--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -87,7 +87,7 @@ impl<W> Serializer<W>
 where
     W: Write,
 {
-    fn new_from_writer(writer: EventWriter<W>) -> Self {
+    pub fn new_from_writer(writer: EventWriter<W>) -> Self {
         Self {
             writer,
             root: true,


### PR DESCRIPTION
Exposes the `Serializer::new_from_writer` constructor to allow users to create a custom `Serializer` from an `xml::EventWriter`.