### PR TITLE
log: add a feature for library logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ version = "0.6.0"
 edition = "2018"
 
 [dependencies]
-log = "0.4"
+log = { version = "0.4", optional = true }
 serde = "1.0"
 xml-rs = "0.8"
 thiserror = "1.0"
@@ -18,3 +18,7 @@ serde = { version = "1.0", features = ["derive"] }
 simple_logger = "2.1"
 docmatic = "0.1"
 rstest = "0.12"
+
+[features]
+default = ["log"]
+log = ["dep:log"]

--- a/src/de/mod.rs
+++ b/src/de/mod.rs
@@ -1,5 +1,6 @@
 use std::{io::Read, marker::PhantomData};
 
+#[cfg(feature = "log")]
 use log::trace;
 use serde::de::{self, Unexpected};
 use serde::forward_to_deserialize_any;
@@ -154,6 +155,7 @@ impl<'de, R: Read, B: BufferedXmlReader<R>> Deserializer<R, B> {
     fn peek(&mut self) -> Result<&XmlEvent> {
         let peeked = self.buffered_reader.peek()?;
 
+        #[cfg(feature = "log")]
         trace!("Peeked {:?}", peeked);
         Ok(peeked)
     }
@@ -171,6 +173,7 @@ impl<'de, R: Read, B: BufferedXmlReader<R>> Deserializer<R, B> {
             }
             _ => {}
         }
+        #[cfg(feature = "log")]
         trace!("Fetched {:?}", next);
         Ok(next)
     }

--- a/src/ser/map.rs
+++ b/src/ser/map.rs
@@ -1,5 +1,6 @@
 use super::{plain::to_plain_string, Serializer};
 use crate::error::{Error, Result};
+#[cfg(feature = "log")]
 use log::debug;
 use serde::ser::Serialize;
 use std::io::Write;
@@ -64,18 +65,22 @@ impl<'ser, W: 'ser + Write> StructSerializer<'ser, W> {
         T: ?Sized + Serialize,
     {
         if key.starts_with("@") {
+            #[cfg(feature = "log")]
             debug!("attribute {}", key);
             self.ser.add_attr(&key[1..], to_plain_string(value)?)
         } else if key == "$value" {
             self.ser.build_start_tag()?;
+            #[cfg(feature = "log")]
             debug!("body");
             value.serialize(&mut *self.ser)?;
             Ok(())
         } else {
             self.ser.build_start_tag()?;
             self.ser.open_tag(key)?;
+            #[cfg(feature = "log")]
             debug!("field {}", key);
             value.serialize(&mut *self.ser)?;
+            #[cfg(feature = "log")]
             debug!("end field");
             Ok(())
         }

--- a/src/ser/mod.rs
+++ b/src/ser/mod.rs
@@ -9,6 +9,7 @@ use self::{
     tuple::TupleSerializer,
 };
 use crate::error::{Error, Result};
+#[cfg(feature = "log")]
 use log::debug;
 use serde::ser::Serialize;
 use std::{collections::HashMap, io::Write};
@@ -269,6 +270,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     }
 
     fn serialize_none(self) -> Result<Self::Ok> {
+        #[cfg(feature = "log")]
         debug!("None");
         let must_close_tag = self.build_start_tag()?;
         if must_close_tag {
@@ -281,11 +283,13 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     where
         T: Serialize,
     {
+        #[cfg(feature = "log")]
         debug!("Some");
         value.serialize(self)
     }
 
     fn serialize_unit(self) -> Result<Self::Ok> {
+        #[cfg(feature = "log")]
         debug!("Unit");
         let must_close_tag = self.build_start_tag()?;
         if must_close_tag {
@@ -295,6 +299,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     }
 
     fn serialize_unit_struct(self, name: &'static str) -> Result<Self::Ok> {
+        #[cfg(feature = "log")]
         debug!("Unit struct {}", name);
         self.serialize_unit()
     }
@@ -305,6 +310,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
         _variant_index: u32,
         variant: &'static str,
     ) -> Result<Self::Ok> {
+        #[cfg(feature = "log")]
         debug!("Unit variant {}::{}", name, variant);
         self.start_tag(variant, HashMap::new())?;
         self.serialize_unit()?;
@@ -316,6 +322,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     where
         T: Serialize,
     {
+        #[cfg(feature = "log")]
         debug!("Newtype struct {}", name);
         value.serialize(self)
     }
@@ -332,6 +339,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     {
         let must_close_tag = self.build_start_tag()?;
 
+        #[cfg(feature = "log")]
         debug!("Newtype variant {}::{}", name, variant);
         self.open_tag(variant)?;
         value.serialize(&mut *self)?;
@@ -343,11 +351,13 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     }
 
     fn serialize_seq(self, _len: Option<usize>) -> Result<Self::SerializeSeq> {
+        #[cfg(feature = "log")]
         debug!("Sequence");
         Ok(SeqSeralizer::new(self))
     }
 
     fn serialize_tuple(self, _len: usize) -> Result<Self::SerializeTuple> {
+        #[cfg(feature = "log")]
         debug!("Tuple");
         let must_close_tag = self.build_start_tag()?;
         Ok(TupleSerializer::new(self, must_close_tag))
@@ -358,6 +368,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
         name: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleStruct> {
+        #[cfg(feature = "log")]
         debug!("Tuple struct {}", name);
         let must_close_tag = self.build_start_tag()?;
         Ok(TupleSerializer::new(self, must_close_tag))
@@ -370,6 +381,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
         variant: &'static str,
         _len: usize,
     ) -> Result<Self::SerializeTupleVariant> {
+        #[cfg(feature = "log")]
         debug!("Tuple variant {}::{}", name, variant);
         let must_close_tag = self.build_start_tag()?;
         self.start_tag(variant, HashMap::new())?;
@@ -384,6 +396,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     fn serialize_struct(self, name: &'static str, _len: usize) -> Result<Self::SerializeStruct> {
         self.open_root_tag(name)?;
 
+        #[cfg(feature = "log")]
         debug!("Struct {}", name);
         Ok(StructSerializer::new(self, false))
     }
@@ -397,6 +410,7 @@ impl<'ser, W: Write> serde::ser::Serializer for &'ser mut Serializer<W> {
     ) -> Result<Self::SerializeStructVariant> {
         self.open_root_tag(name)?;
 
+        #[cfg(feature = "log")]
         debug!("Struct variant {}", variant);
         let must_close_tag = self.build_start_tag()?;
         self.open_tag(variant)?;

--- a/tests/failures.rs
+++ b/tests/failures.rs
@@ -1,6 +1,7 @@
 mod common;
 
 use common::init_logger;
+#[cfg(feature = "log")]
 use log::info;
 use serde::Deserialize;
 use serde_xml_rs::from_str;
@@ -23,6 +24,7 @@ fn simple_struct_from_attributes_should_fail() {
     match item {
         Ok(_) => assert!(false),
         Err(e) => {
+            #[cfg(feature = "log")]
             info!("simple_struct_from_attributes_should_fail(): {}", e);
             assert!(true)
         }
@@ -42,6 +44,7 @@ fn multiple_roots_attributes_should_fail() {
     match item {
         Ok(_) => assert!(false),
         Err(e) => {
+            #[cfg(feature = "log")]
             info!("multiple_roots_attributes_should_fail(): {}", e);
             assert!(true)
         }


### PR DESCRIPTION
Adds a default feature for library logging. No change for existing users, but allows disabling default features to turn off library logging.